### PR TITLE
プレイリストの作成処理

### DIFF
--- a/app/Http/Controllers/SongsController.php
+++ b/app/Http/Controllers/SongsController.php
@@ -36,4 +36,14 @@ class SongsController extends Controller
 
         return back();
     }
+
+    public function destroy($id)
+    {
+        $song=Song::findOrFail($id);
+        if(\Auth::id() == $song->user_id) {
+            $song->delete();
+        }
+
+        return back();
+    }
 }

--- a/app/Http/Controllers/SongsController.php
+++ b/app/Http/Controllers/SongsController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+use App\User; 
+use App\Song; 
+
+class SongsController extends Controller
+{
+    public function create()
+    {
+        $user = \Auth::user();
+        $songs = $user->songs()->orderBy('id', 'desc')->paginate(9);
+        
+        $data = [
+            'user' => $user,
+            'songs' => $songs,
+        ];
+        
+        return view('songs.create', $data);
+    }
+
+    public function store(Request $request)
+    {
+        $this->validate($request,[
+            'url' => 'required',
+            'comment' => 'max:36',
+        ]);
+
+        $request->user()->songs()->create([
+            'url' => $request->url,
+            'comment' => $request->comment,
+        ]);
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+use App\User;
+
+class UsersController extends Controller
+{
+    public function index()
+    {
+        $users = User::orderBy('id','desc')->paginate(9);
+        
+        return view('home', compact('users'));
+    }
+}

--- a/app/Song.php
+++ b/app/Song.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Song extends Model
+{
+    protected $fillable = ['user_id','url','comment'];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -46,4 +46,9 @@ class User extends Authenticatable
     {
         return $this->belongsTo(Country::class);
     }
+
+    public function songs()
+    {
+        return $this->hasMany(Song::class);
+    }
 }

--- a/database/migrations/2021_04_25_052712_create_songs_table.php
+++ b/database/migrations/2021_04_25_052712_create_songs_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateSongsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('songs', function (Blueprint $table) {
+            $table->Increments('id');
+            $table->integer('user_id')->unsigned()->index();
+            $table->string('url');
+            $table->string('comment')->nullable();
+            $table->timestamps();
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('songs');
+    }
+}

--- a/database/seeds/CountryTableSeeder.php
+++ b/database/seeds/CountryTableSeeder.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class CountryTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('countries')->insert([
+            'id' => '1',
+            'country_name' => '日本',
+        ]);
+        DB::table('countries')->insert([
+            'id' => '2',
+            'country_name' => 'Argentina',
+        ]);
+        DB::table('countries')->insert([
+            'id' => '3',
+            'country_name' => 'Brazil',
+        ]);
+        DB::table('countries')->insert([
+            'id' => '4',
+            'country_name' => 'China',
+        ]);
+        DB::table('countries')->insert([
+            'id' => '5',
+            'country_name' => 'France',
+        ]);
+        DB::table('countries')->insert([
+            'id' => '6',
+            'country_name' => 'Italy',
+        ]);
+        DB::table('countries')->insert([
+            'id' => '7',
+            'country_name' => 'Netherlands',
+        ]);
+        DB::table('countries')->insert([
+            'id' => '8',
+            'country_name' => 'Republic of Korea',
+        ]);
+        DB::table('countries')->insert([
+            'id' => '9',
+            'country_name' => 'Spain',
+        ]);
+        DB::table('countries')->insert([
+            'id' => '10',
+            'country_name' => 'United Kingdom',
+        ]);
+        DB::table('countries')->insert([
+            'id' => '11',
+            'country_name' => 'United States of America',
+        ]); 
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $this->call(CountryTableSeeder::class);
     }
 }

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -12,7 +12,7 @@
             <ul class="navbar-nav mr-auto"></ul>
             <ul class="navbar-nav">
                 @if (Auth::check())
-                    <li class="nav-item"><a href="/" class="nav-link text-white">プレイリスト登録</a></li>
+                    <li class="nav-item"><a href="{{ route('songs.create') }}" class="nav-link text-white" name="id" value={{ Auth::id() }}>プレイリスト登録</a></li>
                     <li class="nav-item"><a href="/" class="nav-link text-white">検索</a></li>
                     <li class="nav-item"><a href="/" class="nav-link text-white">いいね</a></li>
                     <li class="nav-item"><a href="/" class="nav-link text-white">ユーザ情報</a></li>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -9,8 +9,10 @@
 
     <div class="text-right">
         @if(Auth::check())
-            {{ Auth::user()->name }}
+            {{ Auth::user()->first_name }}
         @endif
     </div>
+
+    @include('users.users', compact('users'))
 
 @endsection

--- a/resources/views/songs/create.blade.php
+++ b/resources/views/songs/create.blade.php
@@ -1,0 +1,45 @@
+@extends('layouts.app')
+
+@section('content')
+
+    <div class="text-right">
+        {{ Auth::user()->name }}
+    </div>
+
+    <div class="container">
+        <h2 class="mt-5 text-success">Spotifyプレイリスト登録</h2>
+
+        <form action="{{ route('songs.store') }}" method="post">
+        @csrf
+            <div class="form-group mt-5">
+                <label></label>
+                <br>例）PlaylistのURLが <span>https://open.spotify.com/playlist/2LS1HBjVWGLjlYwoizbncs?si=dIo5UbFCTVKgutdeKPqaTQ なら</span>
+                <div>  "playlist/"の直後の "<span class="text-success">2LS1HBjVWGLjlYwoizbncs?si=dIo5UbFCTVKgutdeKPqaTQ</span>" を入力</div>
+                <div class="text-danger">＊プレイリスト以外の登録はできません</div>
+                <input name="url" class='form-control' placeholder="2LS1HBjVWGLjlYwoizbncs?si=dIo5UbFCTVKgutdeKPqaTQ (SpotifyURL入力欄)" autofocus>
+            </div>
+
+            <div class="form-group mt-4">
+                <label name="comment" class="mt-3">Playlistのコメント</label>
+                <input name="comment" class="form-control" placeholder="このプレイリストについてのコメント">
+            </div>    
+                <div class="d-flex justify-content-around col-sm-8 col-auto container">
+                    <input type=submit value="登録" class="btn btn-lg btn-primary mt-5">
+                </div>
+            </div>
+        </from>
+        <div class="text-center mt-3">
+            <a href="https://open.spotify.com/" class="text-center d-inline-block">
+                SpotifyでURLを取得する
+            </a>
+        </div>
+
+        <h2 class="mt-3">Your Playlists</h2>
+
+        @include('songs.songs', compact('songs'))
+
+    </div>
+
+
+
+@endsection

--- a/resources/views/songs/create.blade.php
+++ b/resources/views/songs/create.blade.php
@@ -13,9 +13,9 @@
         @csrf
             <div class="form-group mt-5">
                 <label></label>
-                <br>例）PlaylistのURLが <span>https://open.spotify.com/playlist/2LS1HBjVWGLjlYwoizbncs?si=dIo5UbFCTVKgutdeKPqaTQ なら</span>
-                <div>  "playlist/"の直後の "<span class="text-success">2LS1HBjVWGLjlYwoizbncs?si=dIo5UbFCTVKgutdeKPqaTQ</span>" を入力</div>
-                <div class="text-danger">＊プレイリスト以外の登録はできません</div>
+                <br>例）PlaylistのURLが <span>https://open.spotify.com/playlist/2LS1HBjVWGLjlYwoizbncs?si=dIo5UbFCTVKgutdeKPqaTQ なら</span>
+                <div> &emsp; "<span class="text-success">playlist/</span>"の直後の "<span class="text-success">2LS1HBjVWGLjlYwoizbncs?si=dIo5UbFCTVKgutdeKPqaTQ</span>" を入力</div>
+                <div class="text-danger mt-1 mb-1">＊プレイリスト以外の登録はできません</div>
                 <input name="url" class='form-control' placeholder="2LS1HBjVWGLjlYwoizbncs?si=dIo5UbFCTVKgutdeKPqaTQ (SpotifyURL入力欄)" autofocus>
             </div>
 
@@ -24,7 +24,7 @@
                 <input name="comment" class="form-control" placeholder="このプレイリストについてのコメント">
             </div>    
                 <div class="d-flex justify-content-around col-sm-8 col-auto container">
-                    <input type=submit value="登録" class="btn btn-lg btn-primary mt-5">
+                    <input type="submit" value="登録" class="btn btn-lg btn-primary mt-5">
                 </div>
             </div>
         </from>

--- a/resources/views/songs/songs.blade.php
+++ b/resources/views/songs/songs.blade.php
@@ -1,0 +1,28 @@
+<div class="movies row mt-5 text-center">
+    @foreach ($songs as $key => $song)
+        @if($loop->iteration % 3 == 1 && $loop->iteration != 1)
+            </div>
+            <div class="row text-center mt-3">
+        @endif
+            <div class="col-lg-4 mb-5">
+                <div class="song text-left d-inline-block">
+                    <div>
+                        @if($song)
+                            <iframe src="{{ 'https://open.spotify.com/embed/playlist/'.$song->url }}?controls=1&loop=1&playlist={{ $song->url }}" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+                        @else
+                            <iframe src="https://open.spotify.com/embed/" width="300" height="380" frameborder="0"></iframe>
+                        @endif
+                    </div>
+                    <p>
+                        @if(isset($song->comment))
+                               コメント：{{ $song->comment }}
+                        @else
+                            <span>※コメント登録されてません</span>
+                        @endif
+                    </p>
+                </div>
+            </div>
+    @endforeach
+</div>
+
+{{ $songs->links('pagination::bootstrap-4') }}

--- a/resources/views/songs/songs.blade.php
+++ b/resources/views/songs/songs.blade.php
@@ -1,4 +1,4 @@
-<div class="movies row mt-5 text-center">
+<div class="movies row mt-3 text-center">
     @foreach ($songs as $key => $song)
         @if($loop->iteration % 3 == 1 && $loop->iteration != 1)
             </div>
@@ -8,8 +8,14 @@
                 <div class="song text-left d-inline-block">
                     <div>
                         @if($song)
+                            <div class="text-right">
+                                <span class="badge badge-pill badge-danger">未実装</span>
+                            </div>
                             <iframe src="{{ 'https://open.spotify.com/embed/playlist/'.$song->url }}?controls=1&loop=1&playlist={{ $song->url }}" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
                         @else
+                            <div class="text-right">
+                                <span class="badge badge-pill badge-danger">未実装</span>
+                            </div>
                             <iframe src="https://open.spotify.com/embed/" width="300" height="380" frameborder="0"></iframe>
                         @endif
                     </div>
@@ -20,6 +26,13 @@
                             <span>※コメント登録されてません</span>
                         @endif
                     </p>
+                    @if(Auth::id() == $song->user_id)
+                        <form action="{{ route('songs.destroy', $song->id) }}" method='post'>
+                        @csrf
+                            <input type="hidden" name="_method" value="POST">
+                            <input type="submit" value="プレイリストを削除する" class="button btn btn-danger">
+                        </form>
+                    @endif
                 </div>
             </div>
     @endforeach

--- a/resources/views/users/users.blade.php
+++ b/resources/views/users/users.blade.php
@@ -1,5 +1,5 @@
 
-<h2 class="mt-5 mb-5">users</h2>
+<h2 class="mt-5 mb-5">Users</h2>
 
 <div class="movies row mt-5 text-center">
     @foreach ($users as $key => $user)
@@ -16,11 +16,12 @@
                 <div>
                     @if($song)
                         <div class="text-right">
+                            <span class="badge badge-pill badge-danger">未実装</span>
                         </div>
                         <iframe src="{{ 'https://open.spotify.com/embed/playlist/'.$song->url }}?controls=1&loop=1&playlist={{ $song->url }}" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
                     @else
                         <div class="text-right">
-                            <span class="badge badge-pill badge-danger">未登録</span>
+                            <span class="badge badge-pill badge-danger">未実装</span>
                         </div>
                         <iframe src="https://open.spotify.com/playlist/" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
                     @endif

--- a/resources/views/users/users.blade.php
+++ b/resources/views/users/users.blade.php
@@ -1,0 +1,39 @@
+
+<h2 class="mt-5 mb-5">users</h2>
+
+<div class="movies row mt-5 text-center">
+    @foreach ($users as $key => $user)
+        @php
+            $song=$user->songs->last();
+        @endphp
+        @if($loop->iteration % 3 == 1 && $loop->iteration != 1)
+            </div>
+            <div class="row text-center mt-3">
+        @endif
+        <div class="col-lg-4 mb-5">
+            <div class="movie text-left d-inline-block">
+                <b>{{ $user->first_name }}</b> <span>from</span> {{ $user->country->country_name }}
+                <div>
+                    @if($song)
+                        <div class="text-right">
+                        </div>
+                        <iframe src="{{ 'https://open.spotify.com/embed/playlist/'.$song->url }}?controls=1&loop=1&playlist={{ $song->url }}" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+                    @else
+                        <div class="text-right">
+                            <span class="badge badge-pill badge-danger">未登録</span>
+                        </div>
+                        <iframe src="https://open.spotify.com/playlist/" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+                    @endif
+                </div>
+                <p>
+                    @if(isset($song->comment))
+                        {{ $song->comment }}
+                    @else
+                        <span>※コメント登録されてません</span>
+                    @endif
+                </p>
+            </div>
+        </div>
+    @endforeach
+</div>
+{{ $users->links('pagination::bootstrap-4') }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,9 +10,8 @@
 | contains the "web" middleware group. Now create something great!
 |
 */
-Route::get('/', function () {
-    return view('home', compact('user'));
-});
+
+Route::get('/', 'UsersController@index');
 
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
@@ -21,3 +20,8 @@ Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
 Route::post('login', 'Auth\LoginController@login')->name('login.post');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
+Route::resource('users', 'UsersController', ['only' => ['show']]);
+
+Route::group(['middleware' => 'auth'], function () {
+    Route::resource('songs', 'SongsController', ['only' => ['create', 'store', 'destroy']]);
+});


### PR DESCRIPTION
【追加】
・プレイリスト作成のためにcreateのビューページの作成

・songsコントローラファイルにcreate/storeのメソッドの追加
createメソッド
　ログインのユーザかの確認
　プレイリストの並ぶ順番をidの降順で一つのページに9個表示させるように設定

storeメソッド
　登録される内容にヴァリデーションを追加
　
・国名をプルダウンで表示させるためにシーダファイル・configディレクトリに国名のファイルを作成

Viewファイル
create.blade.php
プレイリスト登録のためのページ

【変更】
home.blade.php
取得したいカラム名が違っていたため変更

header.blade.php
プレイリスト登録ができるようになったので、aタグのhrefにルートを追加

【削除】
トップ画面を表示させるためのルーティングの削除(13~15行目)

【特記事項】
