### PR TITLE
自己紹介カラム・登録フォーム追加

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -63,11 +63,12 @@ class RegisterController extends Controller
             'middle_name' => ['string', 'nullable', 'max:24'],
             'first_name' => ['required', 'string', 'max:24'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users', 'confirmed'],
-            'age_id' => ['required', 'integer', 'max:'. $maxAgeId],
-            'country_id' => ['required', 'integer', 'max:'. $maxCountryId],
-            'sex' => ['required', 'string'],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
-            'insta_id' => ['nullable', 'string', 'max:50'],
+            'country_id' => ['required', 'integer', 'max:' . $maxCountryId],
+            'age_id' => ['required', 'integer', 'max:' . $maxAgeId],
+            'sex' => ['required', 'string'],
+            'self_introduction' => ['required', 'string', 'max:250'],
+            'insta_id' => ['nullable', 'string', 'max:50']
         ]);
     }
 
@@ -84,11 +85,12 @@ class RegisterController extends Controller
             'middle_name' => $data['middle_name'],
             'first_name' => $data['first_name'],
             'email' => $data['email'],
+            'password' => Hash::make($data['password']),
             'country_id' => $data['country_id'],
             'age_id' => $data['age_id'],
             'sex' => $data['sex'],
-            'insta_id' => $data['insta_id'],
-            'password' => bcrypt($data['password']),
+            'self_introduction' => $data['self_introduction'],
+            'insta_id' => $data['insta_id']
         ]);
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -15,6 +15,11 @@ class UsersController extends Controller
 {
     protected $user;
 
+    /**
+     * ファイル内でUserデータをインスタンス化せずに使用可能にしている
+     * 
+     * @param  App\User $user
+     */
     public function __construct(User $user)
     {
         $this->user = $user;
@@ -78,19 +83,30 @@ class UsersController extends Controller
      */
     public function editUser($id)
     {
-        $user = User::findOrFail($id);
-        $registeredCountryName = $user->country->country_name;
-        $registeredAgeName = $user->age->age_name;
-        $sexName = $user->sex;
+        if (Auth::id() == $id) {
+            $user = User::findOrFail($id);
+            $registeredCountryName = $user->country->country_name;
+            $registeredAgeName = $user->age->age_name;
+            $sexName = $user->sex;
 
-        return view('users.user_edit', compact(
-            'user',
-            'registeredCountryName',
-            'registeredAgeName',
-            'sexName'
-        ));
+            return view('users.user_edit', compact(
+                'user',
+                'registeredCountryName',
+                'registeredAgeName',
+                'sexName'
+            ));
+        } else {
+            return back();
+        }
     }
 
+    /**
+     * 自身のユーザ情報を更新する処理
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @param int $id
+     * @return \Illuminate\Http\Response
+     */
     public function updateUser(Request $request, $id)
     {
         $updatingUserInfo = User::findOrFail($id);
@@ -105,6 +121,7 @@ class UsersController extends Controller
                 'country_id',
                 'age_id',
                 'sex',
+                'self_introduction',
                 'insta_id'
             ]);
         // デッドロック時のトランザクションリトライ回数
@@ -119,6 +136,13 @@ class UsersController extends Controller
         return redirect()->route('user.index');
     }
 
+    /**
+     * プレイリスト作成ページでinstagramのID登録or変更する処理
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @param int $id
+     * @return \Illuminate\Http\Response
+     */
     public function updateInstaId(Request $request, $id)
     {
         $updatingUserInfo = User::findOrFail($id);
@@ -142,13 +166,28 @@ class UsersController extends Controller
         return back()->with('flash_message_insta', __('をInstagramのIDとして登録完了'));
     }
 
-    // 削除完了
+    /**
+     * 自身のユーザ情報を削除するページを表示
+     * 
+     * @param int $id
+     * @return \Illuminate\Http\Response
+     */
     public function deletePage($id)
     {
-        $userComfirm = User::findOrFail($id);
-        return view('users.user_confirm', compact('userComfirm'));
+        if (Auth::id() == $id) {
+            $userComfirm = User::findOrFail($id);
+            return view('users.user_confirm', compact('userComfirm'));
+        } else {
+            return back();
+        }
     }
 
+    /**
+     * 自身のユーザ情報を削除する処理
+     * 
+     * @param int $id
+     * @return \Illuminate\Http\Response
+     */
     public function deleteUser($id)
     {
         $deletingUser = User::findOrFail($id);

--- a/app/User.php
+++ b/app/User.php
@@ -29,7 +29,8 @@ class User extends Authenticatable
         'country_id',
         'age_id',
         'sex',
-        'insta_id',
+        'self_introduction',
+        'insta_id'
     ];
 
     /**
@@ -84,6 +85,7 @@ class User extends Authenticatable
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users', 'confirmed'],
             'country_id' => ['required', 'integer', 'max:' . $maxCountryId],
             'age_id' => ['required', 'integer', 'max:' . $maxAgeId],
+            'self_introduction' => ['required', 'string', 'max:250'],
             'insta_id' => ['nullable', 'string', new HalfWidth, 'max:50']
         ];
     }

--- a/database/migrations/2021_06_13_215922_add_user_introduction.php
+++ b/database/migrations/2021_06_13_215922_add_user_introduction.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUserIntroduction extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('self_introduction')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('self_introduction');
+        });
+    }
+}

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -18,6 +18,7 @@ class UsersTableSeeder extends Seeder
             'country_id' => '1',
             'age_id' => '1',
             'sex' => '男性',
+            'self_introduction' => 'これはテストです。',
             'password' => bcrypt('example1'),
             'created_at' => date('Y-m-d H:i:s'),
         ]);
@@ -28,6 +29,7 @@ class UsersTableSeeder extends Seeder
             'country_id' => '1',
             'age_id' => '1',
             'sex' => '女性',
+            'self_introduction' => 'これはテストです。',
             'password' => bcrypt('example2'),
             'created_at' => date('Y-m-d H:i:s'),
         ]);
@@ -38,6 +40,7 @@ class UsersTableSeeder extends Seeder
             'country_id' => '1',
             'age_id' => '2',
             'sex' => '男性',
+            'self_introduction' => 'これはテストです。',
             'password' => bcrypt('example3'),
             'created_at' => date('Y-m-d H:i:s'),
         ]);
@@ -48,6 +51,7 @@ class UsersTableSeeder extends Seeder
             'country_id' => '1',
             'age_id' => '1',
             'sex' => '男性',
+            'self_introduction' => 'これはテストです。',
             'password' => bcrypt('example4'),
             'created_at' => date('Y-m-d H:i:s'),
         ]);
@@ -59,6 +63,7 @@ class UsersTableSeeder extends Seeder
             'country_id' => '11',
             'age_id' => '3',
             'sex' => '男性',
+            'self_introduction' => 'This is a test',
             'password' => bcrypt('example5'),
             'created_at' => date('Y-m-d H:i:s'),
         ]);
@@ -70,6 +75,7 @@ class UsersTableSeeder extends Seeder
             'country_id' => '10',
             'age_id' => '3',
             'sex' => '女性',
+            'self_introduction' => 'This is a test',
             'password' => bcrypt('example6'),
             'created_at' => date('Y-m-d H:i:s'),
         ]);
@@ -80,6 +86,7 @@ class UsersTableSeeder extends Seeder
             'country_id' => '2',
             'age_id' => '2',
             'sex' => '女性',
+            'self_introduction' => 'Esto es una prueba',
             'password' => bcrypt('example7'),
             'created_at' => date('Y-m-d H:i:s'),
         ]);
@@ -90,6 +97,7 @@ class UsersTableSeeder extends Seeder
             'country_id' => '4',
             'age_id' => '4',
             'sex' => '男性',
+            'self_introduction' => '这是一个测试',
             'password' => bcrypt('example8'),
             'created_at' => date('Y-m-d H:i:s'),
         ]);
@@ -100,6 +108,7 @@ class UsersTableSeeder extends Seeder
             'country_id' => '6',
             'age_id' => '6',
             'sex' => '女性',
+            'self_introduction' => 'Questa è una prova',
             'password' => bcrypt('example9'),
             'created_at' => date('Y-m-d H:i:s'),
         ]);
@@ -110,6 +119,7 @@ class UsersTableSeeder extends Seeder
             'country_id' => '5',
             'age_id' => '5',
             'sex' => '男性',
+            'self_introduction' => "C'est un test",
             'password' => bcrypt('example10'),
             'created_at' => date('Y-m-d H:i:s'),
         ]);

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -87,6 +87,12 @@
     padding-left: 5px;
 }
 
+/* 自己紹介のテキストエリアのレイアウト */
+.introduction {
+    vertical-align: top;
+    resize: none;
+}
+
 /* insta_idのレイアウト */
 .insta_btn2 {
     /*ボタンの下地*/

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -170,6 +170,7 @@ return [
         'country_id' => '国名',
         'age_id' => '年齢',
         'sex' => '性別',
+        'self_introduction' => '自己紹介',
         'insta_id' => 'Instagram ID',
         'review' => 'コメント',
     ],

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -50,7 +50,7 @@
                 @endforeach
                 </select>
             </div>
-            <div class="form-group row">
+            <div class="form-group row mb-4">
                 <label class="col-md-4 col-form-label text-md-right" for="radio01">性別</label>
                 <div class="col-md-6 mt-1">
                     <div class="form-check form-check-inline">
@@ -68,8 +68,12 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-sm-4 col-form-label text-sm-center">Instagram&nbsp;ID</label>
-                <input class="col-sm-6" name="insta_id" type="text" placeholder="InstagramのID記述してください" />
+                <label class="col-sm-4 col-form-label text-sm-center" for="self_introduction">自己紹介</label>
+                <textarea class="col-sm-6 introduction" name="self_introduction" placeholder="ここに自己紹介を入力してください" cols="50" rows="5"></textarea>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-4 col-form-label text-sm-center" for="insta_id">Instagram&nbsp;ID</label>
+                <input class="col-sm-6" name="insta_id" type="text" placeholder="(未記入OK)InstagramのID記述してください" />
             </div>
             <div class="d-flex justify-content-around pb-4 col-sm-8 col-auto container">
                 <input class="btn btn-primary" type="submit" value="新規登録">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -54,7 +54,7 @@
             <div class="card-body">
                 <h4 class="card-title">
                     <b>
-                    {{$user->favorites_user->count()}}
+                    {{$user->self_introduction}}
                     </b>
                 </h4>
             </div>

--- a/resources/views/users/user_detail.blade.php
+++ b/resources/views/users/user_detail.blade.php
@@ -32,6 +32,20 @@
             年齢：{{ $user->age->age_name }}
         </h2>
     </div>
+    <div class="col-lg-12 my-3">
+        <div class="card text-center">
+            <div class="card-header">
+                <h4>
+                    <b>自己紹介</b>    
+                </h4>
+            </div>
+            <div class="card-body">
+                <h4 class="card-title">
+                    {{$user->self_introduction}}
+                </h4>
+            </div>
+        </div>
+    </div>
     <div class="col-6">
         @if($user->insta_id)
         <a class="insta_btn2" href="{{ 'https://www.instagram.com/'.$user->insta_id.'/' }}" target="_blank">

--- a/resources/views/users/user_edit.blade.php
+++ b/resources/views/users/user_edit.blade.php
@@ -62,6 +62,10 @@
                     </div>
                 </div>
                 <div class="form-group">
+                    <label class="col-sm-4 col-form-label text-sm-center" for="self_introduction">自己紹介</label>
+                    <textarea class="col-sm-6 introduction" name="self_introduction" placeholder="ここに自己紹介を入力してください" cols="50" rows="5">{{ $user->self_introduction }}</textarea>
+                </div>
+                <div class="form-group">
                     <label class="col-sm-4 col-form-label text-sm-center">Instagram&nbsp;ID</label>
                     <input class="col-sm-6" name="insta_id" type="text" value="{{ $user->insta_id }}" placeholder="InstagramのID記述してください" />
                 </div>


### PR DESCRIPTION
【追加】
- シーダファイルに自己紹介のデータ
- ユーザ登録・変更ページに自己紹介フォーム
- ユーザ詳細ページに自己紹介の内容

【変更】
- ヴァリデーションのルールの順番を登録フォームの順番に変更
- bcrypt→Hash::make